### PR TITLE
Add initial SQL playground web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# SQL-Playground
+# SQL Playground
+
+A simple web application to upload CSV or SQL files and run SQL queries in a temporary SQLite database. Useful for quick experiments without installing any software.
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+python app.py
+```
+
+Then open `http://localhost:5000` in your browser.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,48 @@
+from flask import Flask, request, render_template, jsonify
+import sqlite3
+import pandas as pd
+import io
+from sqlalchemy import text
+
+app = Flask(__name__)
+
+# In-memory SQLite database
+conn = sqlite3.connect(':memory:', check_same_thread=False)
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/upload', methods=['POST'])
+def upload():
+    file = request.files.get('file')
+    if not file:
+        return 'No file uploaded', 400
+
+    filename = file.filename.lower()
+    if filename.endswith('.csv'):
+        df = pd.read_csv(file)
+        table_name = request.form.get('table_name', 'data')
+        df.to_sql(table_name, conn, if_exists='replace', index=False)
+    elif filename.endswith('.sql'):
+        sql_text = file.read().decode('utf-8')
+        with conn:
+            conn.executescript(sql_text)
+    else:
+        return 'Unsupported file type', 400
+
+    return 'File processed successfully', 200
+
+@app.route('/query', methods=['POST'])
+def query():
+    sql = request.form.get('sql')
+    if not sql:
+        return 'No query provided', 400
+    try:
+        df = pd.read_sql_query(sql, conn)
+    except Exception as e:
+        return jsonify({'error': str(e)})
+    return df.to_json(orient='records')
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+pandas
+SQLAlchemy

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,2 @@
+body { font-family: Arial, sans-serif; margin: 20px; }
+textarea { width: 100%; }

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>SQL Playground</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <h1>SQL Playground</h1>
+    <h2>Upload CSV or SQL file</h2>
+    <form id="upload-form" method="post" action="/upload" enctype="multipart/form-data">
+        <input type="file" name="file" required>
+        <input type="text" name="table_name" placeholder="Table name (for CSV)">
+        <button type="submit">Upload</button>
+    </form>
+    <h2>Run Query</h2>
+    <form id="query-form" method="post" action="/query">
+        <textarea name="sql" rows="5" cols="80" placeholder="Enter SQL query"></textarea><br>
+        <button type="submit">Execute</button>
+    </form>
+    <h2>Results</h2>
+    <pre id="results"></pre>
+
+    <script>
+    document.getElementById('query-form').addEventListener('submit', function(evt) {
+        evt.preventDefault();
+        var formData = new FormData(this);
+        fetch('/query', {method: 'POST', body: formData})
+            .then(r => r.json())
+            .then(data => {
+                document.getElementById('results').textContent = JSON.stringify(data, null, 2);
+            });
+    });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- set up Flask application with SQLite backend
- handle CSV/SQL file uploads and run queries
- add minimal UI for query execution
- document setup steps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b70df96988331a18288de9eec91f5