### PR TITLE
Improve UI to mimic SQL Server Management Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# SQL-Playground
+# SQL Playground
+
+A simple web application to upload CSV or SQL files and run SQL queries in a temporary SQLite database. Useful for quick experiments without installing any software.
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+python app.py
+```
+
+Then open `http://localhost:5000` in your browser.
+
+Use the **Show Plan** button to view SQLite's execution plan for a query, similar to SSMS.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,58 @@
+from flask import Flask, request, render_template, jsonify
+import sqlite3
+import pandas as pd
+import io
+from sqlalchemy import text
+
+app = Flask(__name__)
+
+# In-memory SQLite database
+conn = sqlite3.connect(':memory:', check_same_thread=False)
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/upload', methods=['POST'])
+def upload():
+    file = request.files.get('file')
+    if not file:
+        return 'No file uploaded', 400
+
+    filename = file.filename.lower()
+    if filename.endswith('.csv'):
+        df = pd.read_csv(file)
+        table_name = request.form.get('table_name', 'data')
+        df.to_sql(table_name, conn, if_exists='replace', index=False)
+    elif filename.endswith('.sql'):
+        sql_text = file.read().decode('utf-8')
+        with conn:
+            conn.executescript(sql_text)
+    else:
+        return 'Unsupported file type', 400
+
+    return 'File processed successfully', 200
+
+@app.route('/query', methods=['POST'])
+def query():
+    sql = request.form.get('sql')
+    if not sql:
+        return 'No query provided', 400
+
+    # When the client requests an execution plan, use SQLite's EXPLAIN QUERY PLAN
+    if request.form.get('plan'):
+        plan_sql = f"EXPLAIN QUERY PLAN {sql}"
+        try:
+            df = pd.read_sql_query(plan_sql, conn)
+        except Exception as e:
+            return jsonify({'error': str(e)})
+        return df.to_json(orient='records')
+
+    try:
+        df = pd.read_sql_query(sql, conn)
+    except Exception as e:
+        return jsonify({'error': str(e)})
+    return df.to_json(orient='records')
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+pandas
+SQLAlchemy

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,57 @@
+body {
+    margin: 0;
+    font-family: "Segoe UI", Tahoma, sans-serif;
+    background-color: #f3f3f3;
+}
+
+#header {
+    background-color: #0078d7;
+    color: #fff;
+    padding: 10px;
+    font-size: 20px;
+}
+
+#container {
+    display: flex;
+    height: calc(100vh - 40px);
+}
+
+#sidebar {
+    width: 250px;
+    background-color: #fff;
+    border-right: 1px solid #ccc;
+    padding: 10px;
+    box-sizing: border-box;
+}
+
+#main {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    padding: 10px;
+    box-sizing: border-box;
+}
+
+#query-form textarea {
+    width: 100%;
+    height: 200px;
+    font-family: Consolas, monospace;
+}
+
+.toolbar {
+    margin-top: 5px;
+}
+
+#plan-btn {
+    margin-left: 5px;
+}
+
+#results {
+    margin-top: 10px;
+    flex: 1;
+    background-color: #fff;
+    border: 1px solid #ccc;
+    overflow: auto;
+    white-space: pre;
+    padding: 10px;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>SQL Playground</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <div id="header">SQL Playground</div>
+    <div id="container">
+        <div id="sidebar">
+            <h3>Upload CSV or SQL</h3>
+            <form id="upload-form" method="post" action="/upload" enctype="multipart/form-data">
+                <input type="file" name="file" required><br>
+                <input type="text" name="table_name" placeholder="Table name (for CSV)"><br>
+                <button type="submit">Upload</button>
+            </form>
+        </div>
+        <div id="main">
+            <form id="query-form" method="post" action="/query">
+                <textarea name="sql" placeholder="Enter SQL query"></textarea>
+                <div class="toolbar">
+                    <button type="submit">Execute</button>
+                    <button type="button" id="plan-btn">Show Plan</button>
+                </div>
+            </form>
+            <div id="results"></div>
+        </div>
+    </div>
+
+    <script>
+    document.getElementById('query-form').addEventListener('submit', function(evt) {
+        evt.preventDefault();
+        var formData = new FormData(this);
+        fetch('/query', {method: 'POST', body: formData})
+            .then(r => r.json())
+            .then(data => {
+                document.getElementById('results').textContent = JSON.stringify(data, null, 2);
+            });
+    });
+
+    document.getElementById('plan-btn').addEventListener('click', function() {
+        var form = document.getElementById('query-form');
+        var formData = new FormData(form);
+        formData.append('plan', '1');
+        fetch('/query', {method: 'POST', body: formData})
+            .then(r => r.json())
+            .then(data => {
+                document.getElementById('results').textContent = JSON.stringify(data, null, 2);
+            });
+    });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- redesign index page layout with sidebar and header
- style application with SSMS-inspired CSS
- add ability to display SQLite execution plans when running queries

## Testing
- `pip install -r requirements.txt` *(fails: Could not fetch packages)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687b70df96988331a18288de9eec91f5