### PR TITLE
Add visual plan view and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,12 @@ python app.py
 
 Then open `http://localhost:5000` in your browser.
 
-Use the **Show Plan** button to view SQLite's execution plan for a query, similar to SSMS.
+Use the **Show Plan** button to view SQLite's execution plan for a query. The output comes directly from `EXPLAIN QUERY PLAN` and is returned as JSON, not a graphical diagram. Example:
+
+```
+[
+  {"id": 2, "parent": 0, "notused": 0, "detail": "SCAN chatlogs"}
+]
+```
+
+Click **Visual Plan** to see a basic tree rendered from this JSON.

--- a/app.py
+++ b/app.py
@@ -2,7 +2,6 @@ from flask import Flask, request, render_template, jsonify
 import sqlite3
 import pandas as pd
 import io
-from sqlalchemy import text
 
 app = Flask(__name__)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 Flask
 pandas
-SQLAlchemy

--- a/static/style.css
+++ b/static/style.css
@@ -45,6 +45,9 @@ body {
 #plan-btn {
     margin-left: 5px;
 }
+#visual-plan-btn {
+    margin-left: 5px;
+}
 
 #results {
     margin-top: 10px;
@@ -52,6 +55,6 @@ body {
     background-color: #fff;
     border: 1px solid #ccc;
     overflow: auto;
-    white-space: pre;
+    white-space: pre-wrap;
     padding: 10px;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -21,6 +21,7 @@
                 <div class="toolbar">
                     <button type="submit">Execute</button>
                     <button type="button" id="plan-btn">Show Plan</button>
+                    <button type="button" id="visual-plan-btn">Visual Plan</button>
                 </div>
             </form>
             <div id="results"></div>
@@ -46,6 +47,39 @@
             .then(r => r.json())
             .then(data => {
                 document.getElementById('results').textContent = JSON.stringify(data, null, 2);
+            });
+    });
+
+    function buildPlanTree(plan) {
+        var nodes = {};
+        plan.forEach(function(row) {
+            nodes[row.id] = { detail: row.detail, children: [] };
+        });
+        plan.forEach(function(row) {
+            if (row.parent in nodes && row.parent !== row.id) {
+                nodes[row.parent].children.push(nodes[row.id]);
+            }
+        });
+        var roots = plan.filter(function(row) { return !(row.parent in nodes) || row.parent === 0; });
+        function render(node) {
+            var html = '<li>' + node.detail;
+            if (node.children.length) {
+                html += '<ul>' + node.children.map(render).join('') + '</ul>';
+            }
+            html += '</li>';
+            return html;
+        }
+        return '<ul>' + roots.map(function(r) { return render(nodes[r.id]); }).join('') + '</ul>';
+    }
+
+    document.getElementById('visual-plan-btn').addEventListener('click', function() {
+        var form = document.getElementById('query-form');
+        var formData = new FormData(form);
+        formData.append('plan', '1');
+        fetch('/query', {method: 'POST', body: formData})
+            .then(r => r.json())
+            .then(data => {
+                document.getElementById('results').innerHTML = buildPlanTree(data);
             });
     });
     </script>


### PR DESCRIPTION
## Summary
- clarify that `Show Plan` outputs JSON and give example
- add a visual execution plan view
- update styles for new button
- remove unused SQLAlchemy dependency

## Testing
- `python -m py_compile app.py`
- `pip install -q Flask pandas` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_687cbf866e008331ac2c18d85f7fcd8b